### PR TITLE
addes covariance P^hat calculation code in GN only

### DIFF
--- a/gallery/BatchEstimation/PoseGraph_batch/stereo_localization.py
+++ b/gallery/BatchEstimation/PoseGraph_batch/stereo_localization.py
@@ -37,7 +37,7 @@ prior_gt = Pose3(getTrans(C_gt0, r_gt0))   # T_v0_i
 # datastruture: SE3 is a numpy array [4x4]
 # solver = "GN" or "LM"
 # linear_solver = "QR" or "Cholesky"
-options = SolverOptions(solver="LM", iterations=5, linear_solver = "Cholesky", cal_cov=False)   
+options = SolverOptions(solver="GN", iterations=5, linear_solver = "Cholesky", cal_cov=True)   
 graph = FactorGraph(options)
 
 prior_vertex = Vertex.create(vertex_id_counter, prior_gt)


### PR DESCRIPTION
Notes:
1. Only implemented the calculation of covariance part. The later usage of the covariance matrices are not implemented.
2. The covariance calculation is only implemented in the Gauss-Newton method part, although it can be directly copied into the LM part.
3. Delete those lines where "Delete" labels are placed as comments

Regarding the implementation, the only parts we need are actually only the diagonal blocks in the A^-1 matrix. So only (A.21) and (A.20a) from Barfoot's book are needed.