### PR TITLE
fixes a small bug in variance calculation

### DIFF
--- a/gallery/BatchEstimation/PoseGraph_batch/factor_graph/se_factors.py
+++ b/gallery/BatchEstimation/PoseGraph_batch/factor_graph/se_factors.py
@@ -137,7 +137,7 @@ class SE3BetweenFactorTwist(Factor):
         return True
 
     def get_covariance(self, covariance):
-        var = np.concatenate((self.lin_var, self.ang_var), axis=0) * self.dt;
+        var = np.concatenate((self.lin_var, self.ang_var), axis=0) * self.dt * self.dt
         covariance[:,:] = np.diag(np.reciprocal(var))
         return True
 


### PR DESCRIPTION
This fix ensures the covariance to have a unit of [m^2] and [rad^2]. Because the units of `v_var` and `w_var` given in the dataset file are [m^2/s^2] and [rad^2/s^2], respectively, therefore, we should multiply the noise by dt twice to ensure the units comply.